### PR TITLE
feat: add markdown script exporter

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,9 @@
       },
       "project": {
         "description": "Configure Notion projects"
+      },
+      "script": {
+        "description": "Work with cached scripts"
       }
     }
   },

--- a/packages/cli/src/commands/script/export.ts
+++ b/packages/cli/src/commands/script/export.ts
@@ -1,0 +1,26 @@
+import { Args, Command, Flags } from "@oclif/core";
+import { Export, ScriptCache } from "@sprongus/core";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export default class ScriptExport extends Command {
+  static args = {
+    scriptBlockId: Args.string({ description: "Root block ID of the script", required: true })
+  };
+  static description = "Export a cached script to a file";
+  static flags = {
+    format: Flags.string({ char: "f", description: "Exporter format", default: "markdown" }),
+    out: Flags.string({ char: "o", description: "Output file path", required: true })
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(ScriptExport);
+    const { scriptBlockId } = args;
+    const { format, out } = flags;
+    const beats = ScriptCache.listBeatsByScriptId(scriptBlockId);
+    const exporter = Export.resolveScriptExporter(format as Export.ScriptExporterId);
+    const contents = exporter.export(beats);
+    await fs.writeFile(path.resolve(out), contents);
+    this.log(`Script exported to ${out}`);
+  }
+}

--- a/packages/cli/src/commands/script/index.ts
+++ b/packages/cli/src/commands/script/index.ts
@@ -1,0 +1,10 @@
+import { Command } from "@oclif/core";
+
+export default class Script extends Command {
+  static description = "Work with cached scripts";
+
+  async run(): Promise<void> {
+    this.log("Use a subcommand: export");
+    this.log("Run with --help to see all options.");
+  }
+}

--- a/packages/core/src/cache/script.cache.ts
+++ b/packages/core/src/cache/script.cache.ts
@@ -123,3 +123,9 @@ export function deleteBeatByBlockId(blockId: string): void {
 export function deleteBeatsByParentId(parentBlockId: string): void {
   getDb().prepare(`DELETE FROM script_beats WHERE parent_block_id = ?`).run(parentBlockId);
 }
+
+export function listBeatsByScriptId(scriptBlockId: string): ScriptBeat[] {
+  return getDb()
+    .prepare(`SELECT * FROM script_beats WHERE script_block_id = ? ORDER BY index ASC`)
+    .all(scriptBlockId) as ScriptBeat[];
+}

--- a/packages/core/src/export/index.ts
+++ b/packages/core/src/export/index.ts
@@ -1,16 +1,15 @@
-// TODO: Implement script exporter interface
-
 /* Core types used by the exporters */
-import { ScriptDocument } from "../script";            // your existing shape
-import { StoryboardRow } from "../storyboard";        // canonical row type
-import { AuxTableRecord } from "../cache/auxTable.cache";   // generic aux entry
+import { ScriptDocument } from "../script"; // your existing shape
+import { StoryboardRow } from "../storyboard"; // canonical row type
+import { AuxTableRecord } from "../cache/auxTable.cache"; // generic aux entry
+import { markdownExporter } from "./markdown.exporter";
 
 /* ─────────── Interfaces ─────────── */
 
 export interface ScriptExportOptions {
   lineBreak?: "\n" | "\r\n";
   includeIds?: boolean;
-  [key: string]: unknown;                 // exporter-specific flags
+  [key: string]: unknown; // exporter-specific flags
 }
 
 export interface ScriptExporter {
@@ -37,18 +36,17 @@ export interface TableExporter {
 
 /* ─────────── Registry & resolver ─────────── */
 
-// import { plainTextExporter }   from "./plainText.exporter";
-// import { markdownExporter }    from "./script/markdown.exporter";
+const scriptRegistry = {
+  markdown: markdownExporter
+} as const;
 
-// const scriptRegistry = {
-//   "plain-text": plainTextExporter,
-//   markdown:      markdownExporter
-// } as const;
+export type ScriptExporterId = keyof typeof scriptRegistry;
 
-// export type ScriptExporterId = keyof typeof scriptRegistry;
+export function resolveScriptExporter(id: ScriptExporterId): ScriptExporter {
+  return scriptRegistry[id];
+}
 
-// export function resolveScriptExporter(id: ScriptExporterId): ScriptExporter {
-//   return scriptRegistry[id];
-// }
+export { markdownExporter };
 
 /* You can create a similar registry for TableExporter if you like */
+

--- a/packages/core/src/export/markdown.exporter.test.ts
+++ b/packages/core/src/export/markdown.exporter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { markdownExporter } from "./markdown.exporter";
+import type { ScriptBeat } from "../script";
+
+describe("markdownExporter", () => {
+  it("joins beats into markdown", () => {
+    const beats: ScriptBeat[] = [
+      {
+        blockId: "1",
+        parentBlockId: "p",
+        scriptRootBlockId: "root",
+        projectId: "proj",
+        index: 0,
+        html: "<p>One</p>",
+        text: "One",
+        hash: "a",
+        lastFetched: "",
+        lastUpdated: ""
+      },
+      {
+        blockId: "2",
+        parentBlockId: "p",
+        scriptRootBlockId: "root",
+        projectId: "proj",
+        index: 1,
+        html: "<p>Two</p>",
+        text: "Two",
+        hash: "b",
+        lastFetched: "",
+        lastUpdated: ""
+      }
+    ];
+
+    const output = markdownExporter.export(beats);
+    expect(output).toBe("One\n\nTwo");
+  });
+});

--- a/packages/core/src/export/markdown.exporter.ts
+++ b/packages/core/src/export/markdown.exporter.ts
@@ -1,0 +1,20 @@
+import type { ScriptBeat, ScriptDocument } from "../script";
+import type { ScriptExportOptions, ScriptExporter } from "./index";
+
+/**
+ * Simple exporter that joins beat text into a Markdown document.
+ */
+export const markdownExporter: ScriptExporter = {
+  id: "markdown",
+  label: "Markdown",
+  extensions: ["md"],
+  export(script: ScriptDocument, opts: ScriptExportOptions = {}): string {
+    const lineBreak = opts.lineBreak ?? "\n";
+    const beats = script as ScriptBeat[];
+    const chunks = beats.map((beat) => {
+      const idPrefix = opts.includeIds ? `${beat.blockId} ` : "";
+      return `${idPrefix}${beat.text}`;
+    });
+    return chunks.join(`${lineBreak}${lineBreak}`);
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,5 @@ export * as Storyboard from "./storyboard";
 export * as Sync from "./sync";
 export * as Project from "./project";
 export * as Script from "./script";
+export * as Export from "./export";
+


### PR DESCRIPTION
## Summary
- add markdown exporter and registry to core
- expose listBeatsByScriptId helper and export module
- wire up new `script export` CLI command

## Testing
- `pnpm -r build` *(fails: Cannot find module './project' or its type declarations)*
- `pnpm -r test` *(fails: CLI hello tests failed)*
- `pnpm -r lint` *(fails: unresolved imports and undefined functions in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ba937b308331b5c97c11ea69c698